### PR TITLE
Added apache 2 license to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Builds a table of contents into the Etherpad interface
 
-Enable under settings
+Enable under settings.
 Create headings, watch the TOC populate in real time.
 
-#License
+##License
 Copyright 2014, John McLear
 
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Like suggested in https://github.com/JohnMcLear/ep_table_of_contents/issues/17 I added the Apache 2 License. For sake of simplicity I kept the license note in the readme.md and gave it a h2 heading. 
