### PR TITLE
fix: enable/disable the plugin via querystring

### DIFF
--- a/static/js/postAceInit.js
+++ b/static/js/postAceInit.js
@@ -26,12 +26,11 @@ exports.postAceInit = () => {
     tableOfContents.disable();
   }
 
-  const urlContainstocTrue =
-  (tableOfContents.getParam('toc') === 'true'); // if the url param is set
+  const urlContainstocTrue = tableOfContents.getParam('toc'); // if the url param is set
   if (urlContainstocTrue) {
     $('#options-toc').attr('checked', 'checked');
     tableOfContents.enable();
-  } else if (tableOfContents.getParam('toc') === 'false') {
+  } else {
     $('#options-toc').attr('checked', false);
     tableOfContents.disable();
   }

--- a/static/js/toc.js
+++ b/static/js/toc.js
@@ -131,14 +131,9 @@ const tableOfContents = {
   },
 
   getParam: (sname) => {
-    let params = location.search.substr(location.search.indexOf('?') + 1);
-    let sval = '';
-    params = params.split('&');
-    // split param and value into individual pieces
-    for (let i = 0; i < params.length; i++) {
-      const temp = params[i].split('=');
-      if ([temp[0]] === sname) { sval = temp[1]; }
-    }
+    let sval = true;
+    const urlParams = new URLSearchParams(location.href);
+    if(urlParams.get(sname) === "false") sval = false;
     return sval;
   },
 


### PR DESCRIPTION
Enable and Disabling the plugin via query string not working! (`http://example.com/padName?toc=false`)

I refactored the `getParam` function and use `URLSearchParams` API to obtain search query string params, in order to make it easier to read and maintain.
