### PR TITLE
🐛 – Fix verification of `toc` parameter in URL

### DIFF
--- a/static/js/postAceInit.js
+++ b/static/js/postAceInit.js
@@ -27,11 +27,13 @@ exports.postAceInit = () => {
   }
 
   const urlContainstocTrue = tableOfContents.getParam('toc'); // if the url param is set
-  if (urlContainstocTrue) {
-    $('#options-toc').attr('checked', 'checked');
-    tableOfContents.enable();
-  } else {
-    $('#options-toc').attr('checked', false);
-    tableOfContents.disable();
+  if (typeof(urlContainstocTrue) !== 'undefined') {
+    if (urlContainstocTrue) {
+      $('#options-toc').attr('checked', 'checked');
+      tableOfContents.enable();
+    } else {
+      $('#options-toc').attr('checked', false);
+      tableOfContents.disable();
+    }
   }
 };

--- a/static/js/toc.js
+++ b/static/js/toc.js
@@ -131,10 +131,11 @@ const tableOfContents = {
   },
 
   getParam: (sname) => {
-    let sval = true;
-    const urlParams = new URLSearchParams(location.href);
-    if (urlParams.get(sname) === 'false') sval = false;
-    return sval;
+    const urlParams = new URLSearchParams(location.search);
+    if (urlParams.has(sname)) {
+      return !(urlParams.get(sname) === 'false');
+    }
+    return null;
   },
 
 };


### PR DESCRIPTION
[URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) asks for a query string as constructor argument (`?foo=bar`), not a full URL.