### PR TITLE
Use correct variable name

### DIFF
--- a/templates/toc_entry.ejs
+++ b/templates/toc_entry.ejs
@@ -1,4 +1,4 @@
 <p>
-<input type="checkbox" id="options-toc" <%= checked %>></input>
+<input type="checkbox" id="options-toc" <%= checkedState %>></input>
 <label for="options-toc" data-l10n-id="ep_table_of_contents.toc">Table of Contents</label>
 </p>


### PR DESCRIPTION
~~Fixes #58.~~

On [lines 38/39 of `index.js`](https://github.com/ether/ep_table_of_contents/blob/5a62f5a1b0421cfbc996abde1e85ebea8bd19aa2/index.js#L38-L39), the TOC's default state is set using the `checkedState` variable, which is passed to `toc_entry.ejs`. However, `toc_entry.ejs` reads the `checked` variable instead. This PR fixes that issue by using `checkedState` instead in `toc_entry.ejs`.