### PR TITLE
Fix hiding/displaying TOC from URL and settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,15 +27,13 @@ exports.eejsBlock_scripts = (hookName, args, cb) => {
 };
 
 exports.eejsBlock_mySettings = (hookName, args, cb) => {
-  let checkedState = 'unchecked';
-  if (settings.ep_toc) {
-    if (settings.ep_toc.disable_by_default === true) {
-      checkedState = 'unchecked';
-    } else {
-      checkedState = 'checked';
-    }
+  let checkedAttribute = 'checked';
+
+  if (settings.ep_toc && settings.ep_toc.disable_by_default === true) {
+    checkedAttribute = '';
   }
+
   args.content +=
-      eejs.require('./templates/toc_entry.ejs', {checked: checkedState}, module);
+      eejs.require('./templates/toc_entry.ejs', {checked: checkedAttribute}, module);
   return cb();
 };

--- a/static/js/postAceInit.js
+++ b/static/js/postAceInit.js
@@ -30,7 +30,7 @@ exports.postAceInit = () => {
   if (urlContainstocParam === true) {
     $('#options-toc').attr('checked', 'checked');
     tableOfContents.enable();
-  } else if (urlContainstocParam === false) {
+  } else if (urlContainstocParam === false || window.innerWidth < 600) {
     $('#options-toc').attr('checked', false);
     tableOfContents.disable();
   }

--- a/static/js/postAceInit.js
+++ b/static/js/postAceInit.js
@@ -26,11 +26,11 @@ exports.postAceInit = () => {
     tableOfContents.disable();
   }
 
-  const urlContainstocTrue = tableOfContents.getParam('toc'); // if the url param is set
-  if (urlContainstocTrue) {
+  const urlContainstocParam = tableOfContents.getParam('toc'); // if the url param is set
+  if (urlContainstocParam === true) {
     $('#options-toc').attr('checked', 'checked');
     tableOfContents.enable();
-  } else {
+  } else if (urlContainstocParam === false) {
     $('#options-toc').attr('checked', false);
     tableOfContents.disable();
   }

--- a/static/js/toc.js
+++ b/static/js/toc.js
@@ -131,10 +131,10 @@ const tableOfContents = {
   },
 
   getParam: (sname) => {
-    let sval = true;
-    const urlParams = new URLSearchParams(location.href);
-    if (urlParams.get(sname) === 'false') sval = false;
-    return sval;
+    const urlParams = new URLSearchParams(location.search);
+    if (urlParams.get(sname) === 'false') return false;
+    if (urlParams.get(sname) === 'true') return true;
+    return undefined;
   },
 
 };


### PR DESCRIPTION
 * (fix) Fix `toc` param handling: auto hide if `toc=false`, auto display if `toc=true`
 * (fix) Auto hide toc if `toc.disable_by_default` setting is `true`
 * (fix/feature) Auto hide toc if screen width is under 600px