### PR TITLE
disable _by_default not working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ep_table_of_contents",
-  "version": "0.3.54",
+  "version": "0.3.55",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ep_table_of_contents",
-  "version": "0.3.54",
+  "version": "0.3.55",
   "description": "View a table of contents for your pad",
   "author": {
     "name": "John McLear",

--- a/static/js/postAceInit.js
+++ b/static/js/postAceInit.js
@@ -30,8 +30,5 @@ exports.postAceInit = () => {
   if (urlContainstocTrue) {
     $('#options-toc').attr('checked', 'checked');
     tableOfContents.enable();
-  } else {
-    $('#options-toc').attr('checked', false);
-    tableOfContents.disable();
   }
 };


### PR DESCRIPTION
I believe this change resolves the issue with disable_by_default not working. the process to check the url for the toc param was always returning true, overriding the config.

NB this is my first time doing anything with nodejs so I could have it all wrong but it seems to fix the issue.