### PR TITLE
Fix: ?toc=false URL param now correctly disables TOC (#157)

### DIFF
--- a/static/js/postAceInit.js
+++ b/static/js/postAceInit.js
@@ -27,9 +27,12 @@ exports.postAceInit = () => {
     tableOfContents.disable();
   }
 
-  const urlContainstocTrue = tableOfContents.getParam('toc'); // if the url param is set
-  if (urlContainstocTrue) {
+  const tocParam = tableOfContents.getParam('toc');
+  if (tocParam === true) {
     optionToc.prop('checked', true);
     tableOfContents.enable();
+  } else if (tocParam === false) {
+    optionToc.prop('checked', false);
+    tableOfContents.disable();
   }
 };

--- a/static/js/toc.js
+++ b/static/js/toc.js
@@ -175,7 +175,12 @@ const tableOfContents = {
 
   getParam: (sname) => {
     const urlParams = new URLSearchParams(window.location.search);
-    return urlParams.has(sname);
+    if (!urlParams.has(sname)) return null;
+    const value = urlParams.get(sname);
+    // ?toc with no value or ?toc=true means enable
+    // ?toc=false means disable
+    if (value === 'false') return false;
+    return true;
   },
 
 };


### PR DESCRIPTION
## Summary

Fixes #157 — `?toc=false` URL param was being treated as "enable TOC" because `getParam` only checked if the parameter existed, not its value.

Now `?toc=false` disables the TOC, `?toc` or `?toc=true` enables it, and no param respects the settings default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)