### PR TITLE
fix: debounce ToC heading scan to fix typing lag (#51)

### DIFF
--- a/static/js/toc.js
+++ b/static/js/toc.js
@@ -159,11 +159,34 @@ const tableOfContents = {
     $(`.tocItem[data-toc-index="${activeTocIndex}"]`).addClass('activeTOC');
   },
 
+  // findTags() walks every heading and rebuilds the entire ToC DOM. On
+  // pads with hundreds of headings this blocked the main thread on
+  // every keystroke and produced the 1-char-per-second typing seen in
+  // #51. Debounce the expensive scan — still fast enough to feel
+  // responsive, but no longer fires per keystroke.
+  _findTagsTimer: null,
+  _findTagsPending: false,
+  scheduleFindTags: (rep) => {
+    if (tableOfContents._findTagsTimer != null) {
+      tableOfContents._findTagsPending = true;
+      return;
+    }
+    tableOfContents._findTagsTimer = setTimeout(() => {
+      tableOfContents._findTagsTimer = null;
+      tableOfContents.findTags();
+      if (tableOfContents._findTagsPending) {
+        tableOfContents._findTagsPending = false;
+        tableOfContents.scheduleFindTags();
+      }
+    }, 300);
+  },
+
   update: (rep) => {
     if (rep) {
       tableOfContents.showPosition(rep);
     }
-    tableOfContents.getPadHTML(rep);
+    if (!$('#options-toc').is(':checked')) return;
+    tableOfContents.scheduleFindTags(rep);
   },
 
   scroll: (newY) => {

--- a/static/tests/backend/specs/debounce.js
+++ b/static/tests/backend/specs/debounce.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const assert = require('assert').strict;
+const fs = require('fs');
+const path = require('path');
+
+const tocPath = path.resolve(__dirname, '..', '..', '..', '..', 'static', 'js', 'toc.js');
+
+describe(__filename, function () {
+  let src;
+  before(function () { src = fs.readFileSync(tocPath, 'utf8'); });
+
+  it('update() debounces findTags() via setTimeout (#51)', function () {
+    // findTags walks every heading and rebuilds the #tocItems list. On pads
+    // with hundreds of headings, firing it on every keystroke was the
+    // source of the 1-char-per-second typing seen in #51. The update path
+    // must now schedule findTags via setTimeout instead of calling it
+    // synchronously.
+    const updateBlock = src.match(/update:\s*\([^)]*\)\s*=>\s*\{[\s\S]*?\n\s*\},/);
+    assert(updateBlock, 'expected update() in tableOfContents');
+    assert(!/tableOfContents\.findTags\s*\(\s*\)/.test(updateBlock[0]),
+        'update() must not call findTags() synchronously on every edit');
+    assert(/scheduleFindTags|setTimeout/.test(updateBlock[0]),
+        'update() should defer the heading scan (via scheduleFindTags / setTimeout)');
+    // And the scheduler itself should actually use setTimeout.
+    assert(/scheduleFindTags[\s\S]*?setTimeout/.test(src),
+        'scheduleFindTags should wrap findTags() in setTimeout');
+  });
+});


### PR DESCRIPTION
Fixes #51. `findTags()` walks every heading and rebuilds `#tocItems` from scratch, and `update()` called it synchronously on every edit. With ~150 titles the main thread was blocked hard enough to drop typing to roughly 1 char/second. Route `update()` through a new `scheduleFindTags()` helper that wraps `findTags()` in a 300ms `setTimeout`, coalescing rapid edits into a single scan. Also bail early if the ToC checkbox is unchecked so edits don't do any ToC work at all. Backend spec asserts `update()` no longer calls `findTags()` synchronously and that the scheduler wraps it in `setTimeout`.