### PR TITLE
visual enhancement for readability

### DIFF
--- a/static/css/toc.css
+++ b/static/css/toc.css
@@ -7,38 +7,50 @@
   overflow-y: auto;
 }
 #tocItems{
-  line-height:200%;
+  line-height:1.4 !important;
 }
 .tocItem{
-  white-space: nowrap;
-  text-overflow: ellipsis;
   display: block;
-  overflow: hidden;
   cursor:pointer;
 }
-
+a.tocItem{
+  text-decoration-color: transparent;
+  text-underline-offset: 0.2em;
+  white-space: unset;
+}
+a:hover.tocItem{
+  text-decoration-color: inherit;
+}
 .tocDepth1{
   margin-left:0px;
   font-size: 1.5rem;
 }
+.tocDepth1:not(:first-child) {
+  margin-top:0.5rem
+}
 .tocDepth2{
   margin-left:10px;
+  margin-top:0.5rem;
   font-size: 1.2rem;
 }
 .tocDepth3{
   margin-left:20px;
+  margin-top:0.25rem;
   font-size: 1rem;
 }
 .tocDepth4{
   margin-left:30px;
+  margin-top:0.25rem;
   font-size:1rem;
 }
 .tocDepth5{
   margin-left:30px;
+  margin-top:0.25rem;
   font-size:1rem;
 }
 .tocDepth6{
   margin-left:30px;
+  margin-top:0.25rem;
   font-size:1rem;
 }
 


### PR DESCRIPTION
Hi,

Just some CSS changes to enhance readability. TOC takes less space, titles are not cropped with ellipsis and they span multiple lines, underline only on :hover, minor margin adjustments.
There is plenty of room for improvement but I think it is a good brick added to the wall.

Cheers