### PR TITLE
feat: migrate to ep_plugin_helpers padToggle for User + Pad Wide settings

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -3,18 +3,22 @@
     {
       "name": "ep_table_of_contents",
       "hooks": {
+        "loadSettings"                : "ep_table_of_contents/index",
+        "clientVars"                  : "ep_table_of_contents/index",
         "eejsBlock_scripts"           : "ep_table_of_contents/index",
         "eejsBlock_styles"            : "ep_table_of_contents/index",
         "eejsBlock_mySettings"        : "ep_table_of_contents/index",
+        "eejsBlock_padSettings"       : "ep_table_of_contents/index",
         "eejsBlock_editorContainerBox": "ep_table_of_contents/index",
         "eejsBlock_dd_view"           : "ep_table_of_contents/index",
         "eejsBlock_editbarMenuRight"  : "ep_table_of_contents/index"
       },
       "client_hooks":{
-        "aceEditEvent"           : "ep_table_of_contents/static/js/aceEditEvent:aceEditEvent",
-        "handleClientMessage_ACCEPT_COMMIT"           : "ep_table_of_contents/static/js/aceEditEvent:aceEditEvent",
-        "handleClientMessage_NEW_CHANGES"           : "ep_table_of_contents/static/js/aceEditEvent:aceEditEvent",
-        "postAceInit"            : "ep_table_of_contents/static/js/postAceInit:postAceInit"
+        "aceEditEvent"                       : "ep_table_of_contents/static/js/aceEditEvent:aceEditEvent",
+        "handleClientMessage_ACCEPT_COMMIT"  : "ep_table_of_contents/static/js/aceEditEvent:aceEditEvent",
+        "handleClientMessage_NEW_CHANGES"    : "ep_table_of_contents/static/js/aceEditEvent:aceEditEvent",
+        "handleClientMessage_CLIENT_MESSAGE" : "ep_table_of_contents/static/js/postAceInit:handleClientMessage_CLIENT_MESSAGE",
+        "postAceInit"                        : "ep_table_of_contents/static/js/postAceInit:postAceInit"
       }
     }
   ]

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const eejs = require('ep_etherpad-lite/node/eejs');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
-const {padToggle} = require('ep_plugin_helpers');
+const {padToggle} = require('ep_plugin_helpers/pad-toggle-server');
 
 // Parallel User Settings + Pad Wide Settings checkboxes for TOC visibility.
 // Helper owns the storage, broadcast, enforce, and i18n wiring.

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const tocToggle = padToggle({
   pluginName: 'ep_table_of_contents',
   settingId: 'toc',
   l10nId: 'ep_table_of_contents.toc',
+  defaultLabel: 'Show Table of Contents',
   defaultEnabled: false,
 });
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,21 @@
 
 const eejs = require('ep_etherpad-lite/node/eejs');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
+const {padToggle} = require('ep_plugin_helpers');
+
+// Parallel User Settings + Pad Wide Settings checkboxes for TOC visibility.
+// Helper owns the storage, broadcast, enforce, and i18n wiring.
+const tocToggle = padToggle({
+  pluginName: 'ep_table_of_contents',
+  settingId: 'toc',
+  l10nId: 'ep_table_of_contents.toc',
+  defaultEnabled: false,
+});
+
+exports.loadSettings = tocToggle.loadSettings;
+exports.clientVars = tocToggle.clientVars;
+exports.eejsBlock_mySettings = tocToggle.eejsBlock_mySettings;
+exports.eejsBlock_padSettings = tocToggle.eejsBlock_padSettings;
 
 exports.eejsBlock_styles = (hookName, args, cb) => {
   args.content +=
@@ -30,19 +45,5 @@ exports.eejsBlock_editbarMenuRight = (hookName, args, cb) => {
 exports.eejsBlock_scripts = (hookName, args, cb) => {
   args.content +=
   "<script src='../static/plugins/ep_table_of_contents/static/js/toc.js'></script>";
-  return cb();
-};
-
-exports.eejsBlock_mySettings = (hookName, args, cb) => {
-  let checkedState = 'unchecked';
-  if (settings.ep_toc) {
-    if (settings.ep_toc.disable_by_default === true) {
-      checkedState = 'unchecked';
-    } else {
-      checkedState = 'checked';
-    }
-  }
-  args.content +=
-      eejs.require('./templates/toc_entry.ejs', {checked: checkedState}, module);
   return cb();
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "type": "individual",
     "url": "https://etherpad.org/"
   },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.3.0"
+  },
   "devDependencies": {
     "eslint": "^8.57.1",
     "eslint-config-etherpad": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ep_table_of_contents",
-  "version": "0.3.140",
+  "version": "0.4.0",
   "description": "View a table of contents for your pad",
   "author": {
     "name": "John McLear",

--- a/static/js/postAceInit.js
+++ b/static/js/postAceInit.js
@@ -21,6 +21,7 @@ const tocToggle = padToggle({
   pluginName: 'ep_table_of_contents',
   settingId: 'toc',
   l10nId: 'ep_table_of_contents.toc',
+  defaultLabel: 'Show Table of Contents',
   defaultEnabled: false,
 });
 

--- a/static/js/postAceInit.js
+++ b/static/js/postAceInit.js
@@ -1,6 +1,10 @@
 'use strict';
 
-const {padToggle} = require('ep_plugin_helpers');
+// Sub-path import keeps the client bundle clean. Importing the top-level
+// `ep_plugin_helpers` index pulls in every helper's getters; `settings` and
+// `toggle` reach server-only modules (eejs, Settings) which esbuild can't
+// resolve for the browser.
+const {padToggle} = require('ep_plugin_helpers/pad-toggle');
 
 // postAceInit is loaded as a CommonJS plugin hook module; its scope is not
 // the same as the <script> tag that loads toc.js, so `tableOfContents` is

--- a/static/js/postAceInit.js
+++ b/static/js/postAceInit.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {padToggle} = require('ep_plugin_helpers');
+
 // postAceInit is loaded as a CommonJS plugin hook module; its scope is not
 // the same as the <script> tag that loads toc.js, so `tableOfContents` is
 // not visible via the normal scope chain. Look it up explicitly on the
@@ -8,6 +10,19 @@
 const getToc = () => (typeof globalThis !== 'undefined' && globalThis.tableOfContents) ||
     (window.top && window.top.tableOfContents) ||
     window.tableOfContents || null;
+
+// Same config as the server-side instance — must agree on pluginName,
+// settingId, and l10nId for the checkbox ids and clientVars lookup to line up.
+const tocToggle = padToggle({
+  pluginName: 'ep_table_of_contents',
+  settingId: 'toc',
+  l10nId: 'ep_table_of_contents.toc',
+  defaultEnabled: false,
+});
+
+// Re-export so the helper sees pad-wide broadcasts and refreshes our state
+// when another user toggles the pad-wide checkbox.
+exports.handleClientMessage_CLIENT_MESSAGE = tocToggle.handleClientMessage_CLIENT_MESSAGE;
 
 exports.postAceInit = () => {
   if (!$('#editorcontainerbox').hasClass('flex-layout')) {
@@ -21,28 +36,20 @@ exports.postAceInit = () => {
   }
   const toc = getToc();
   if (!toc) return;
-  const optionToc = $('#options-toc');
-  /* on click */
-  optionToc.on('click', () => {
-    if (optionToc.is(':checked')) {
-      toc.enable(); // enables line tocping
-    } else {
-      optionToc.prop('checked', false);
-      toc.disable(); // disables line tocping
-    }
-  });
-  if (optionToc.is(':checked')) {
-    toc.enable();
-  } else {
-    toc.disable();
-  }
 
+  const state = tocToggle.init({
+    onChange: (enabled) => { enabled ? toc.enable() : toc.disable(); },
+  });
+
+  // ?toc=true / ?toc=false URL parameter still overrides the resolved
+  // setting, matching the pre-migration behavior.
   const tocParam = toc.getParam('toc');
-  if (tocParam === true) {
-    optionToc.prop('checked', true);
-    toc.enable();
-  } else if (tocParam === false) {
-    optionToc.prop('checked', false);
-    toc.disable();
+  if (tocParam === true || tocParam === false) {
+    tocParam ? toc.enable() : toc.disable();
+    $('#options-toc').prop('checked', tocParam);
+  } else {
+    // No URL override — make sure the editor matches the helper's effective
+    // value. (init() already fired onChange once, so this is belt-and-braces.)
+    void state;
   }
 };

--- a/templates/toc_entry.ejs
+++ b/templates/toc_entry.ejs
@@ -1,4 +1,0 @@
-<p>
-<input type="checkbox" id="options-toc" <%= checked %>></input>
-<label for="options-toc" data-l10n-id="ep_table_of_contents.toc">Table of Contents</label>
-</p>


### PR DESCRIPTION
## Summary
- Switch from the hand-rolled `eejsBlock_mySettings` checkbox to `padToggle` from `ep_plugin_helpers ^0.3.0`.
- Renders **two** checkboxes — User Settings (per-user, cookie) and Pad Wide Settings (per-pad, broadcast, honored by `enforceSettings`) — instead of just the user-side one. Matches every native Etherpad toggle.
- Helper owns checkbox rendering, cookie persistence, broadcast sync, enforce semantics, i18n via `data-l10n-id`, and screen-reader fallback inside `<label>`.
- Hand-rolled `templates/toc_entry.ejs` deleted; `?toc=` URL override still works as a hard override on top.
- Bump to 0.4.0 for the helper-and-core-patch peer requirement.

## Dependencies
- ep_plugin_helpers ^0.3.0 — needs to be published before this PR can merge (separate PR: ether/ep_plugin_helpers#8).
- etherpad-lite ep_* padOptions passthrough patch (separate PR: ether/etherpad-lite#7698) — required for the Pad Wide Settings half to work. Without it, only User Settings renders and behaves exactly like today's UX, so this PR is forward-compatible — the pad-wide column lights up the moment users upgrade core.

## Test plan
- [x] Existing TOC numbering tests still pass (6/6).
- [x] Live two-checkbox render verified on patched Etherpad: options-toc + padsettings-options-toc, both with data-l10n-id=ep_table_of_contents.toc and screen-reader fallback "Show Table of Contents" inside <label>.
- [ ] Two-browser broadcast + enforce verified in Playwright once core patch + helper publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)