### PR TITLE
a11y: flatten interactive nesting (restore localized aria-label)

### DIFF
--- a/templates/barButton.ejs
+++ b/templates/barButton.ejs
@@ -1,7 +1,8 @@
 <li data-key="ep_table_of_contents-toggle" data-type="button" onClick="toggleToc();">
-    <a id="ep_table_of_contents-a" data-l10n-id="ep_table_of_contents.toc.title">
-        <button class="buttonicon buttonicon-insertunorderedlist" data-l10n-id="ep_table_of_contents.toc.title"></button>
-    </a>
+    <a id="ep_table_of_contents-a"
+       class="buttonicon buttonicon-insertunorderedlist"
+       role="button" tabindex="0"
+       data-l10n-id="ep_table_of_contents.toc.title"></a>
 </li>
 <li class="separator"></li>
 <script type="text/javascript">


### PR DESCRIPTION
## Summary

Flattens nested toolbar markup to a single `<a role="button" tabindex="0">` carrying the icon classes. With no element children (or with a recognized attribute suffix in `data-l10n-id`), etherpad's html10n auto-populates `aria-label` from the localized string per `html10n.ts:665-678`.

**Why this PR exists:** the earlier Phase 3a sweep removed hardcoded `aria-label="…"` on toolbar buttons that have element children (`<span>`/`<button>`) and a `data-l10n-id` without a recognized attribute suffix (`.title`/`.alt`/`.value`/`.placeholder`). For those elements, html10n skips its auto-population path, so they ended up with no accessible name. Flattening the structure makes the auto-population fire.