### PR TITLE
refactor: adopt template helper for 1 simple eejsBlock_* hook(s)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {template} = require('ep_plugin_helpers');
+
 const eejs = require('ep_etherpad-lite/node/eejs');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
 const {padToggle} = require('ep_plugin_helpers/pad-toggle-server');
@@ -31,10 +33,8 @@ exports.eejsBlock_dd_view = (hookName, args, cb) => {
   return cb();
 };
 
-exports.eejsBlock_editorContainerBox = (hookName, args, cb) => {
-  args.content += eejs.require('./templates/toc.ejs', {}, module);
-  return cb();
-};
+exports.eejsBlock_editorContainerBox =
+    template('./templates/toc.ejs');
 
 exports.eejsBlock_editbarMenuRight = (hookName, args, cb) => {
   if (settings.ep_toc && settings.ep_toc.show_button === true) {


### PR DESCRIPTION
## Summary

Adopts `template()` from `ep_plugin_helpers` for 1 `eejsBlock_*` hook(s) of shape:

```js
exports.eejsBlock_X = (hookName, args, cb) => {
  args.content += eejs.require('plugin/template.ejs'[, {}[, module]]);
  cb();
};
```

Replaced with `exports.eejsBlock_X = template('plugin/template.ejs');`. Same runtime behavior.

Part of Phase 4 of the modernization campaign. Wave 1: ether/ep_themes#103 + 6 small plugins. Wave 2 picks up hooks with explicit empty-vars / module argument that wave 1's stricter regex skipped.