### PR TITLE
fix: use absolute template paths for ep_plugin_helpers template()

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ exports.eejsBlock_dd_view = (hookName, args, cb) => {
 };
 
 exports.eejsBlock_editorContainerBox =
-    template('./templates/toc.ejs');
+    template('ep_table_of_contents/templates/toc.ejs');
 
 exports.eejsBlock_editbarMenuRight = (hookName, args, cb) => {
   if (settings.ep_toc && settings.ep_toc.show_button === true) {


### PR DESCRIPTION
## Summary

Fixes runtime resolution failure for templates introduced by the earlier Phase 4 `template` helper adoption.

`ep_plugin_helpers/eejs-blocks.js` calls `eejs.require(templatePath, vars, module)` with **its own** module reference. `eejs.require` uses that module's `__dirname` as the resolve basedir, so a relative path like `./templates/styles.html` resolves against `ep_plugin_helpers/` (not this plugin's directory) and fails.

This PR rewrites `template('./templates/X')` to `template('ep_table_of_contents/templates/X')`. With an absolute path of the shape `<plugin>/<file>`, etherpad's `pluginInstallPath` resolution kicks in and locates the file correctly.

This should land before the next end-user upgrades to a build that ships these plugins, otherwise affected blocks will throw at render time.